### PR TITLE
add github prefix to `source_repo`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           cd ${WORK_DIR}
 
           # Build command arguments
-          COMMAND_ARGS="--out-dir ${OUTPUT} --meta source_repo=${{ github.repository }}"
+          COMMAND_ARGS="--out-dir ${OUTPUT} --meta source_repo=github:${{ github.repository }}"
           if [ "${{ inputs.package }}" ]; then
               COMMAND_ARGS="--package ${{ inputs.package }} $COMMAND_ARGS"
               PACKAGE_NAME=${{ inputs.package }}


### PR DESCRIPTION
This PR adds a `github:` prefix to the `source_repo` contract meta.

### Rationale

Both the original [protocol discussion](https://github.com/orgs/stellar/discussions/1573) and the draft [SEP-55](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0055.md) specify this prefix. There seems to be broad consensus that the prefix is a good idea.

### Immediate impact

Stellar Lab only populates its Build Info tab with keys that [include the prefix](https://github.com/stellar/laboratory/blob/67df3fad215d9f4c59cdf10ab850da01038e63bc/src/query/useWasmGitHubAttestation.ts#L105). Contract binaries that have been built and attested with this workflow, currently show up as "Build Unverified". Merging this PR could solve the issue for future builds.